### PR TITLE
新增保洁员获取管辖农户积分排行榜接口

### DIFF
--- a/src/main/java/com/work/recycle/component/OrdersComponent.java
+++ b/src/main/java/com/work/recycle/component/OrdersComponent.java
@@ -21,7 +21,6 @@ import static java.util.Optional.ofNullable;
 
 /**
  * 订单插入 审核组件
- *
  */
 @Component
 @Slf4j
@@ -228,6 +227,11 @@ public class OrdersComponent {
 
      */
 
+    /**
+     * 保存垃圾选择集合
+     * @param baseOrder 基础订单
+     * @param garbageChooses 垃圾选择信息集合
+     */
     public void addBaseOrderGarbageList(BaseOrder baseOrder, List<GarbageChoose> garbageChooses) {
         ofNullable(garbageChooses)
                 .ifPresent(item -> item.forEach(each -> garbageRepository.findById(

--- a/src/main/java/com/work/recycle/component/SiftOrdersComponent.java
+++ b/src/main/java/com/work/recycle/component/SiftOrdersComponent.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.stream.Collectors;
 
-// TODO 2020:11/15 进行测试
 @Slf4j
 @Component
 public class SiftOrdersComponent {

--- a/src/main/java/com/work/recycle/controller/CleanerController.java
+++ b/src/main/java/com/work/recycle/controller/CleanerController.java
@@ -14,6 +14,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,10 +39,11 @@ public class CleanerController {
     public CommonResult getFCOrdersChecking(@RequestBody SiftOrderVo siftOrderVo) {
         return CommonResult.success(cleanerService.getFCOrderChecking(siftOrderVo));
     }
-    
+
 
     /**
      * 获得农户提交审核完成订单
+     *
      * @return 订单vo list
      */
     @PostMapping("getFCOrders/checked")
@@ -52,8 +54,9 @@ public class CleanerController {
     /**
      * ------------ 弃用 -------------
      * 由于保洁员和农户之间是严格的一对多的关系，在创建时就已经完成接单，相当于自动接单
-     *
+     * <p>
      * 接收农户订单
+     *
      * @param id 订单id
      * @return null
      */
@@ -64,6 +67,7 @@ public class CleanerController {
 
     /**
      * 保洁员审核农户提交的订单
+     *
      * @param baseOrder the baseOrder
      * @return null
      */
@@ -71,12 +75,13 @@ public class CleanerController {
     public CommonResult checkFCOrder(@RequestBody BaseOrder baseOrder) {
         List<GarbageChoose> garbageChooseList = baseOrder.getGarbageChooses();
         baseOrder.setGarbageChooses(null);
-        cleanerService.checkFCOrder(baseOrder,garbageChooseList);
+        cleanerService.checkFCOrder(baseOrder, garbageChooseList);
         return CommonResult.success(null);
     }
 
     /**
      * 添加保洁员 - 司机订单
+     *
      * @param baseOrder the baseOrder
      * @return null
      */
@@ -84,7 +89,7 @@ public class CleanerController {
     public CommonResult addCDOrder(@RequestBody BaseOrder baseOrder) {
         List<GarbageChoose> garbageChooses = baseOrder.getGarbageChooses();
         baseOrder.setGarbageChooses(null);
-        cleanerService.addCDOrder(baseOrder,garbageChooses);
+        cleanerService.addCDOrder(baseOrder, garbageChooses);
         return CommonResult.success(null);
     }
 
@@ -92,44 +97,44 @@ public class CleanerController {
     /**
      * 获得基础订单信息
      * {
-     *   "code": 200,
-     *   "message": "操作成功",
-     *   "data": {
-     *     "id": 3,
-     *     "score": 485.0,
-     *     "checkStatus": false,
-     *     "remark": "管理员提交一条记录",
-     *     "garbageChooses": [
-     *       {
-     *         "id": 5,
-     *         "garbage": {
-     *           "id": 1,
-     *           "name": "纸壳、硬纸板",
-     *           "category": "可回收垃圾",
-     *           "type": "纸张类",
-     *           "score": 25.0,
-     *           "unit": "斤",
-     *           "picture": "http://localhost:8080/static/1.jpg"
-     *         },
-     *         "amount": 5.0
-     *       },
-     *       {
-     *         "id": 6,
-     *         "garbage": {
-     *           "id": 2,
-     *           "name": "废旧资料、旧报纸 ",
-     *           "category": "可回收垃圾",
-     *           "type": "纸张类",
-     *           "score": 60.0,
-     *           "unit": "斤",
-     *           "picture": "http://localhost:8080/static/2.jpg"
-     *         },
-     *         "amount": 6.0
-     *       }
-     *     ],
-     *     "insertTime": "2020-10-25T11:28:51",
-     *     "updateTime": "2020-10-25T11:28:51"
-     *   }
+     * "code": 200,
+     * "message": "操作成功",
+     * "data": {
+     * "id": 3,
+     * "score": 485.0,
+     * "checkStatus": false,
+     * "remark": "管理员提交一条记录",
+     * "garbageChooses": [
+     * {
+     * "id": 5,
+     * "garbage": {
+     * "id": 1,
+     * "name": "纸壳、硬纸板",
+     * "category": "可回收垃圾",
+     * "type": "纸张类",
+     * "score": 25.0,
+     * "unit": "斤",
+     * "picture": "http://localhost:8080/static/1.jpg"
+     * },
+     * "amount": 5.0
+     * },
+     * {
+     * "id": 6,
+     * "garbage": {
+     * "id": 2,
+     * "name": "废旧资料、旧报纸 ",
+     * "category": "可回收垃圾",
+     * "type": "纸张类",
+     * "score": 60.0,
+     * "unit": "斤",
+     * "picture": "http://localhost:8080/static/2.jpg"
+     * },
+     * "amount": 6.0
+     * }
+     * ],
+     * "insertTime": "2020-10-25T11:28:51",
+     * "updateTime": "2020-10-25T11:28:51"
+     * }
      * }
      */
     @GetMapping("getBaseOrderById")
@@ -139,6 +144,7 @@ public class CleanerController {
 
     /**
      * 获取积分和提交次数展示
+     *
      * @return {
      *   "code": 200,
      *   "message": "操作成功",
@@ -154,8 +160,8 @@ public class CleanerController {
      */
     @GetMapping("getOrderInfo")
     public CommonResult getOrderInfo() {
-        Map map = Map.of("score",cleanerService.getScore());
-        Map map1 = Map.of("times",cleanerService.getFCOrderTimes());
+        Map map = Map.of("score", cleanerService.getScore());
+        Map map1 = Map.of("times", cleanerService.getFCOrderTimes());
         List<Map> list = new ArrayList<>();
         list.add(map);
         list.add(map1);
@@ -178,32 +184,103 @@ public class CleanerController {
     }
 
 
-    // TODO 2020:11/14 进行测试
     @PostMapping("addFarmer")
     public CommonResult addFarmer(@RequestBody User user) {
         return CommonResult.success(cleanerService.addFarmer(user));
     }
 
-    //  /**
-    //   * 获取积分排行榜
-    //   * @return the cleaner list
-    //   */
-    //  @GetMapping("getRankList")
-    //  public CommonResult getRankList() {
-    //      List<Cleaner> cleaners = cleanerService.getRankList();
-    //      List<RankListVo> rankListVos = new ArrayList<>();
-    //      cleaners.forEach(each -> rankListVos.add(new RankListVo(each.getUser().getName(),each.getScore(), each.getId())));
-    //      return CommonResult.success(rankListVos);
-    //  }
 
-    // TODO 2020:11/15 进行测试
     @PostMapping("getRankList")
     public CommonResult getRankList(@RequestBody AddressVo addressVo) {
         List<Cleaner> cleaners = cleanerService.getRankList(addressVo);
         List<RankListVo> rankListVos = new ArrayList<>();
-        cleaners.forEach(each -> rankListVos.add(new RankListVo(each.getUser().getName(),each.getScore(), each.getId())));
+        cleaners.forEach(each -> rankListVos.add(
+                new RankListVo(
+                        each.getUser().getName()
+                        , each.getScore()
+                        , each.getId()
+                        , AddressVo.getAddressVo(each.getUser())
+                )
+        ));
         return CommonResult.success(rankListVos);
     }
 
+    /**
+     * 保洁员获取管辖用户列表
+     *
+     * @return {
+     * "code": 200,
+     * "message": "操作成功",
+     * "data": [
+     * {
+     * "phoneNumber": "13050496542",
+     * "name": "农户姓名",
+     * "id": 3
+     * },
+     * {
+     * "phoneNumber": "15941627298",
+     * "name": "安慕希",
+     * "id": 7,
+     * "village": "伟业村"
+     * }
+     * }
+     */
+    @GetMapping("getFarmers")
+    public CommonResult getFarmer() {
+        List<Map<String, Object>> list = new ArrayList<>();
+        cleanerService.getFarmer()
+                .forEach(farmer -> {
+                    Map<String, Object> map = new HashMap();
+                    map.put("name", farmer.getUser().getName());
+                    map.put("id", farmer.getId());
+                    map.put("village", farmer.getUser().getVillage());
+                    map.put("phoneNumber", farmer.getUser().getPhoneNumber());
+                    list.add(map);
+                });
+        return CommonResult.success(list);
+    }
+
+    /**
+     * 获取某一个用户的详细信息
+     *
+     * @param id 农户id
+     * @return {
+     * "code": 200,
+     * "message": "操作成功",
+     *      "data": {
+     *          "id": 7,
+     *          "user": {
+     *              "id": 7,
+     *              "name": "安慕希",
+     *              "phoneNumber": "15941627298",
+     *              "role": "FARMER",
+     *              "province": "黑龙江省",
+     *              "city": "大庆市",
+     *              "area": "双城区",
+     *              "street": "平安街道",
+     *              "village": "伟业村"
+     *          },
+     *          "familySize": 1,
+     *          "score": 0.0
+     *      }
+     * }
+     */
+    @GetMapping("getFarmer/index")
+    public CommonResult getFarmerIndex(int id) {
+        return CommonResult.success(cleanerService.getFarmerIndex(id));
+    }
+
+    @GetMapping("getFarmerRanklist")
+    public CommonResult getFarmerRanklist() {
+        List<Farmer> farmers = cleanerService.getFarmerRankList();
+        List<RankListVo> rankListVos = new ArrayList<>();
+        farmers.forEach(each -> rankListVos.add(new RankListVo(each.getUser().getName(), each.getScore(), each.getId())));
+        return CommonResult.success(rankListVos);
+    }
+
+    @PostMapping("removeCDOrders")
+    public CommonResult removeCDOrders(@Param("id") int id) {
+        return CommonResult.success(cleanerService.removeCDOrder(id));
+    }
 
 }

--- a/src/main/java/com/work/recycle/controller/FarmerController.java
+++ b/src/main/java/com/work/recycle/controller/FarmerController.java
@@ -168,7 +168,6 @@ public class FarmerController {
     }
 
 
-    // TODO 2020:11/15 进行测试
     /**
      * 获取积分前十名的用户
      * @return 返回农户排行榜集合
@@ -183,7 +182,20 @@ public class FarmerController {
 
     // TODO 2020/10/22 ：删除订单
     @PostMapping("removeFCOrder")
-    public CommonResult removeFCOrder() {
-        return null;
+    public CommonResult removeFCOrder(@Param("id") int id) {
+        return CommonResult.success(farmerService.removeFCOrder(id));
+    }
+
+    // TODO 2020:11/20 获取对应保洁员
+    /**
+     * 农户获取对应保洁员
+     * @return {
+     *     name : XXX,
+     *     id : XX
+     * }
+     */
+    @GetMapping("getCleaner")
+    public CommonResult getCleaner() {
+        return CommonResult.success(farmerService.getCleaner());
     }
 }

--- a/src/main/java/com/work/recycle/controller/vo/AddressVo.java
+++ b/src/main/java/com/work/recycle/controller/vo/AddressVo.java
@@ -1,8 +1,15 @@
 package com.work.recycle.controller.vo;
 
+import com.work.recycle.common.ResultCode;
+import com.work.recycle.entity.User;
+import com.work.recycle.exception.ApiException;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AddressVo {
     public static final String PROVINCE = "province";
     public static final String CITY = "city";
@@ -15,4 +22,17 @@ public class AddressVo {
     private String area;
     private String street;
     private String village;
+
+    public static AddressVo getAddressVo(User user) {
+        if (user == null ) {
+            throw new ApiException(ResultCode.FAILED);
+        }
+        return new AddressVo(
+                user.getProvince()
+                ,user.getCity()
+                ,user.getArea()
+                ,user.getStreet()
+                ,user.getStreet()
+        );
+    }
 }

--- a/src/main/java/com/work/recycle/controller/vo/RankListVo.java
+++ b/src/main/java/com/work/recycle/controller/vo/RankListVo.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RankListVo {
     private String name;
-    private String address;
     private double score;
     private Integer id;
+    private AddressVo addressVo;
 
     public RankListVo(String name,double score,Integer id) {
         this.name = name;
@@ -20,4 +20,5 @@ public class RankListVo {
         this.id = id;
 
     }
+
 }

--- a/src/main/java/com/work/recycle/repository/FarmerRepository.java
+++ b/src/main/java/com/work/recycle/repository/FarmerRepository.java
@@ -21,6 +21,8 @@ public interface FarmerRepository extends BaseRepository<Farmer,Integer> {
     @Query("select f from Farmer f where f.user.phoneNumber = :phoneNumber")
     Farmer getFarmerByPhoneNumber(@Param("phoneNumber") String PhoneNumber);
 
+    @Query("select f.cleaner from Farmer f where f.id = :id")
+    Cleaner getCleaner(@Param("id") int id);
 
     List<Farmer> findTop10ByOrderByScoreDesc();
 
@@ -33,4 +35,8 @@ public interface FarmerRepository extends BaseRepository<Farmer,Integer> {
     List<Farmer> findTop10ByUser_StreetOrderByScoreDesc(String street);
 
     List<Farmer> findTop10ByUser_VillageOrderByScoreDesc(String village);
+
+    List<Farmer> findTop10ByCleaner_IdOrderByScoreDesc(int id);
+
+    List<Farmer> findByCleaner_Id(int id);
 }

--- a/src/main/java/com/work/recycle/repository/GarbageChooseRepository.java
+++ b/src/main/java/com/work/recycle/repository/GarbageChooseRepository.java
@@ -4,8 +4,13 @@ import com.work.recycle.entity.GarbageChoose;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface GarbageChooseRepository extends BaseRepository<GarbageChoose,Integer> {
 
     @Query("select g from GarbageChoose g where g.id = :id")
     GarbageChoose getGarbageChooseById(@Param("id") int id);
+
+    @Query("select g from GarbageChoose g where g.baseOrder.id = :id")
+    List<GarbageChoose> getGarbageChooseByBaseOrder_Id(@Param("id") int id);
 }

--- a/src/test/java/com/work/recycle/controller/CleanerControllerTest.java
+++ b/src/test/java/com/work/recycle/controller/CleanerControllerTest.java
@@ -1,0 +1,59 @@
+package com.work.recycle.controller;
+
+import com.work.recycle.entity.Cleaner;
+import com.work.recycle.entity.Farmer;
+import com.work.recycle.entity.User;
+import com.work.recycle.repository.CleanerRepository;
+import com.work.recycle.repository.FarmerRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest
+
+@Slf4j
+class CleanerControllerTest {
+
+    @Autowired
+    private FarmerRepository farmerRepository;
+    @Autowired
+    private PasswordEncoder encoder;
+    @Autowired
+    private CleanerRepository cleanerRepository;
+
+    @Test
+    void test_addFarmer() {
+        Cleaner cleaner = cleanerRepository.getCleanerById(2);
+        for (int i = 0; i < 20; i++) {
+            String name = "农户姓名" + i;
+            String phoneNum = "130504965" + i;
+            User user = new User();
+            user.setName(name);
+            user.setPhoneNumber(phoneNum);
+            user.setPassword(encoder.encode("123456"));
+            user.setRole(User.Role.FARMER);
+            user.setVillage("手机村");
+            Farmer farmer = new Farmer();
+            farmer.setUser(user);
+            farmer.setScore(i);
+            farmer.setCleaner(cleaner);
+            farmerRepository.save(farmer);
+        }
+    }
+
+    @Test
+    void getFarmer() {
+
+    }
+
+    @Test
+    void getFarmerRanklist() {
+    }
+
+    @Test
+    void removeCROrders() {
+    }
+}

--- a/src/test/java/com/work/recycle/http/test.http
+++ b/src/test/java/com/work/recycle/http/test.http
@@ -1,3 +1,37 @@
+POST http://localhost:8080/api/farmer/removeFCOrder?id=9
+Content-Type: application/json
+Authorization: 139c2fbebadbd5a7d23baa1933854de84a3516e2c3b6cd8923ae7d40d1da3208807c992e36c3c75f447151d4270b7612
+
+{}
+
+###
+GET http://localhost:8080/api/farmer/getCleaner
+Accept: application/json
+Authorization: 139c2fbebadbd5a7d23baa1933854de84a3516e2c3b6cd8923ae7d40d1da3208807c992e36c3c75f447151d4270b7612
+
+###
+POST http://localhost:8080/api/cleaner/removeCROrders?id=3
+Content-Type: application/json
+Authorization: c7f9fb9a8461a21c669b6cd05d4fab40852a1c7c8cce406802034a19a22140b0e3d69a5f46c7f3b2bef6219155aa7d57
+
+{}
+
+###
+GET http://localhost:8080/api/cleaner/getFarmerRanklist
+Accept: application/json
+Authorization: c7f9fb9a8461a21c669b6cd05d4fab40852a1c7c8cce406802034a19a22140b0e3d69a5f46c7f3b2bef6219155aa7d57
+
+###
+GET http://localhost:8080/api/cleaner/getFarmer/index?id=7
+Accept: application/json
+Authorization: c7f9fb9a8461a21c669b6cd05d4fab40852a1c7c8cce406802034a19a22140b0e3d69a5f46c7f3b2bef6219155aa7d57
+
+###
+GET http://localhost:8080/api/cleaner/getFarmers
+Accept: application/json
+Authorization: c7f9fb9a8461a21c669b6cd05d4fab40852a1c7c8cce406802034a19a22140b0e3d69a5f46c7f3b2bef6219155aa7d57
+
+###
 POST http://localhost:8080/api/cleaner/getRankList
 Content-Type: application/json
 Authorization: c7f9fb9a8461a21c669b6cd05d4fab40852a1c7c8cce406802034a19a22140b0e3d69a5f46c7f3b2bef6219155aa7d57

--- a/src/test/java/com/work/recycle/service/CleanerServiceTest.java
+++ b/src/test/java/com/work/recycle/service/CleanerServiceTest.java
@@ -98,4 +98,9 @@ class CleanerServiceTest {
             cleanerRepository.save(cleaner);
         }
     }
+
+    @Test
+    void removeCDOrder() {
+        cleanerService.removeCDOrder(6);
+    }
 }


### PR DESCRIPTION
1.新增保洁员获取管辖农户积分排行榜接口
2.新增保洁员获取所管辖农户列表接口
3.新增保洁员获取农户详情接口
4.新增保洁员删除未审核的CROrder订单接口
5.新增农户对应保洁员接口
6.新增农户删除未审核的FCOrder订单接口